### PR TITLE
Add counter feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,9 +55,10 @@ def load_bot_token():
     return 'default_token'  # Replace with your actual bot token
 
 # Initialize the counter if the file doesn't exist
-if not os.path.exists(counter_file):
-    with open(counter_file, 'w') as f:
-        json.dump({}, f)
+def init_counter_file():
+    if not os.path.exists(counter_file):
+        with open(counter_file, 'w') as f:
+            json.dump({}, f)
 
 # Function to read counter value from file with fcntl locking
 def get_counter():
@@ -149,4 +150,5 @@ def counter():
     return jsonify(dict(get_counter()))
 
 if __name__ == '__main__':
+    init_counter_file()
     app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -1,12 +1,17 @@
 from flask import Flask, request, jsonify
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
+from collections import defaultdict
 import base64
 import os
 import requests
 import time
+import fcntl
+import json
+import hashlib
 
 app = Flask(__name__)
+counter_file = 'counter.json'
 
 # --- Encryption functions with fixed IV (all zeros) ---
 
@@ -49,6 +54,34 @@ def load_bot_token():
             return f.read().strip()
     return 'default_token'  # Replace with your actual bot token
 
+# Initialize the counter if the file doesn't exist
+if not os.path.exists(counter_file):
+    with open(counter_file, 'w') as f:
+        json.dump({}, f)
+
+# Function to read counter value from file with fcntl locking
+def get_counter():
+    with open(counter_file, 'r') as f:
+        # Acquire a lock before reading the file
+        fcntl.flock(f, fcntl.LOCK_SH)  # Shared lock (read-only)
+        data = json.load(f)
+        fcntl.flock(f, fcntl.LOCK_UN)  # Release the lock
+    return data
+
+# Function to update counter in the file with fcntl locking
+def update_counter(counter_by_hash):
+    with open(counter_file, 'w') as f:
+        # Acquire a lock before writing to the file
+        fcntl.flock(f, fcntl.LOCK_EX)  # Exclusive lock (write)
+        json.dump(counter_by_hash, f)
+        fcntl.flock(f, fcntl.LOCK_UN)  # Release the lock
+
+def deterministic_hash(encoded_id):
+    # Create a SHA256 hash of the input encoded_id
+    hash_object = hashlib.sha256(encoded_id.encode('utf-8'))
+    # Get the first 8 digits of the hash as an integer
+    return str(int(hash_object.hexdigest(), 16) % (10 ** 8))
+
 # --- Endpoints ---
 
 @app.route('/register', methods=['POST'])
@@ -90,6 +123,9 @@ def notify():
     data = request.get_json()
     encoded_id = data.get('encodedID', '')
     retries = data.get('notifyRetries', 1)
+    notify_counter_by_hash = defaultdict(int, get_counter())
+    notify_counter_by_hash[deterministic_hash(encoded_id)] += 1
+    update_counter(dict(notify_counter_by_hash))
     
     key = load_key()
     try:
@@ -107,6 +143,10 @@ def notify():
         time.sleep(1)
     
     return jsonify({'status': 'notifications sent'})
+
+@app.route('/counter')
+def counter():
+    return jsonify(dict(get_counter()))
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Add a way to register the number of notifications by the encoded_id (hashed), and return it in the new /counter endpoint.